### PR TITLE
Start making batch size modular

### DIFF
--- a/patho_sam/automatic_segmentation.py
+++ b/patho_sam/automatic_segmentation.py
@@ -223,6 +223,29 @@ def automatic_segmentation_wsi(
     return segmentations
 
 
+def _find_best_batch_size():
+    if torch.cuda.is_available():
+
+        # Check how much memory we have and select the best matching batch size for the available VRAM size.
+        _, vram = torch.cuda.mem_get_info()
+        vram = vram / 1e9  # in GB
+
+        # Maybe we can get more configurations in the future.
+        if vram > 80:  # More than 80 GB
+            return 30
+        elif vram > 30:  # More than 30 GB
+            return 10
+        elif vram > 14:  # More than 14 GB
+            return 5
+        elif vram > 8:  # More than 8 GB
+            return 3
+        else:  # Otherwise, not enough memory to parallelize tilewise prediction on GPU. Do it sequentially.
+            return 1
+
+    else:  # On any other device, we cannot find this automatically. Hence, do this sequentially.
+        return 1
+
+
 def main():
     """@private"""
     import argparse
@@ -281,8 +304,9 @@ def main():
         "By default the most performant available device will be selected."
     )
     parser.add_argument(
-        "--batch_size", type=int, default=1,
-        help="The batch size for computing image embeddings with tiling. By default, set to 1."
+        "--batch_size", type=int, default=_find_best_batch_size(),
+        help="The batch size for computing image embeddings with tiling. "
+        "By default, sets to the most compatible combination as per VRAM, otherwise 1."
     )
 
     args = parser.parse_args()
@@ -305,6 +329,14 @@ def main():
         view=args.view,
         batch_size=args.batch_size,
     )
+
+    # NOTE:
+    # 1) instances
+    #    encoder: 36:41, decoder: 8:46, post-processing: 46:32
+    # 2) semantic
+    #    ...
+    # 3) both
+    #    ...
 
     # Calculate the end time of the process.
     end_time = time.time()


### PR DESCRIPTION
This PR relies on VRAM availability to set the `batch_size`.

Working on this, I realized we are missing the batching implementation in the semantic segmentation pipeline (my fault tbh, didn't keep it up-to-date with `micro-sam`).

I will sit down with this today evening and sync it up with the decoder parallelization with batch size support!