### PR TITLE
Add mentions for example notebooks in `micro-sam`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,9 +1,11 @@
 # Example Scripts
 
-Examples for using the `micro_sam` annotation tools:
+Examples for using the [`micro_sam`](https://github.com/computational-cell-analytics/micro-sam) annotation tools:
 
 - `annotator_2d_wsi.py`: Run the interactive 2d annotation tool, suitable for whole-slide images (WSIs).
 - `annotator_2d.py`: Run the interactive 2d annotation tool.
 - `train_pannuke_semantic.py`: Train a model for semantic segmentation of nuclei in PanNuke histopathology images.
+
+We provide Jupyter Notebooks for using automatic segmentation and finetuning on some example data in the [notebooks](https://github.com/computational-cell-analytics/micro-sam/tree/master/notebooks) folder located in the `micro-sam` repository.
 
 The folder `finetuning` contains example scripts that show how a Segment Anything model can be fine-tuned on custom data with the `micro_sam.train` library, and how the finetuned models can then be used within the `micro_sam` annotation tools.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,6 @@ Examples for using the [`micro_sam`](https://github.com/computational-cell-analy
 - `annotator_2d.py`: Run the interactive 2d annotation tool.
 - `train_pannuke_semantic.py`: Train a model for semantic segmentation of nuclei in PanNuke histopathology images.
 
-We provide Jupyter Notebooks for using automatic segmentation and finetuning on some example data in the [notebooks](https://github.com/computational-cell-analytics/micro-sam/tree/master/notebooks) folder located in the `micro-sam` repository.
+There are Jupyter Notebooks available for using automatic segmentation and finetuning on some example data in the [notebooks](https://github.com/computational-cell-analytics/micro-sam/tree/master/notebooks) folder located in the `micro-sam` repository.
 
 The folder `finetuning` contains example scripts that show how a Segment Anything model can be fine-tuned on custom data with the `micro_sam.train` library, and how the finetuned models can then be used within the `micro_sam` annotation tools.


### PR DESCRIPTION
This PR updates the README file inside the `examples` folder to point users to example notebooks, where there are latest notebooks for automatic and interactive segmentation, and finetuning scripts as well!

I will go ahead and merge this!