### PR TITLE
Remove verbose argument from schedulers and minor linting fixes

### DIFF
--- a/experiments/training/README.md
+++ b/experiments/training/README.md
@@ -2,6 +2,6 @@
 
 This folder contains scripts for finetuning a generalist model for nuclei instance segmentation in histopathology H&E stained images. Here is a brief mention of the folders:
 - `generalists`: Contains scripts for training our generalist `patho-sam` models, on a large histopathology dataset for nuclei (automatic and interactive) instance segmentation, inspired by `micro-sam`.
-- `specialists`: Contains scripts for training our specialist `patho-sam` models, on PanNuke (for nuclei), GlaS (for glands), NuClick (for lymphocytes) and PUMA (for neutrophils) for data-specific exploration.
+- `specialists`: Contains scripts for training our specialist `patho-sam` models, on PanNuke (for nuclei), GlaS (for glands), NuClick (for lymphocytes) and PUMA (for neutrophils) for task-/data-specific exploration.
 
 > NOTE: The scripts should run out-of-the-box and download most datasets automatically. For some datasets, automatic downloads are not supported. See the respective `get_generalist_datasets.py` or `get_specialist_dataset.py` for details about their downloads!

--- a/experiments/training/generalists/get_generalist_datasets.py
+++ b/experiments/training/generalists/get_generalist_datasets.py
@@ -106,6 +106,7 @@ def get_generalist_hp_loaders(patch_shape, data_path):
     # Get the datasets
     generalist_train_dataset = get_concat_hp_datasets(path=data_path, patch_shape=patch_shape, split_choice="train")
     generalist_val_dataset = get_concat_hp_datasets(path=data_path, patch_shape=patch_shape, split_choice="val")
+
     # Get the dataloaders
     train_loader = torch_em.get_data_loader(generalist_train_dataset, batch_size=2, shuffle=True, num_workers=16)
     val_loader = torch_em.get_data_loader(generalist_val_dataset, batch_size=1, shuffle=True, num_workers=16)

--- a/experiments/training/generalists/train_generalist_histopathology.py
+++ b/experiments/training/generalists/train_generalist_histopathology.py
@@ -23,7 +23,7 @@ def finetune_generalist(args):
 
     # all the stuff we need for training
     train_loader, val_loader = get_generalist_hp_loaders(patch_shape=patch_shape, data_path=args.input_path)
-    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10, "verbose": True}
+    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10}
 
     # Run training.
     sam_training.train_sam(

--- a/experiments/training/specialists/finetune_specialist.py
+++ b/experiments/training/specialists/finetune_specialist.py
@@ -25,7 +25,7 @@ def finetune_specialist(args):
     train_loader, val_loader = get_specialist_loaders(
         patch_shape=patch_shape, data_path=args.input_path, dataset=args.dataset
     )
-    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10, "verbose": True}
+    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10}
 
     # Run training.
     sam_training.train_sam(


### PR DESCRIPTION
This PR removes verbose argument from scheduler kwargs, as it is discontinued `pytorch` 2.7 onwards, and makes some minor liniting and syntax updates.

I will go ahead and merge this!